### PR TITLE
Add file absolute path comparison in file filter in push command.

### DIFF
--- a/src/Openl10n/Cli/Command/PushCommand.php
+++ b/src/Openl10n/Cli/Command/PushCommand.php
@@ -105,7 +105,13 @@ class PushCommand extends AbstractCommand
                 }
 
                 // Skip unwanted files
-                if (!empty($fileFilter) && !in_array($file->getRelativePathname(), $fileFilter)) {
+                if (
+                    !empty($fileFilter) 
+                    && !(
+                        in_array($file->getAbsolutePathname(), $fileFilter) 
+                        || in_array($file->getRelativePathname(), $fileFilter)
+                    )
+                ) {
                     continue;
                 }
 


### PR DESCRIPTION
In `$fileFilter`, I have an absolute path.
With the comparison `!in_array($file->getRelativePathname(), $fileFilter)`, I can't push any file.
I added the relative path comparison for cover all possibilities.
