### PR TITLE
Allow binary to be included in existing project

### DIFF
--- a/bin/openl10n
+++ b/bin/openl10n
@@ -1,7 +1,16 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
+$autoloadFiles = array(
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+);
+
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+    }
+}
 
 (new Openl10n\Cli\ApplicationFactory())
     ->createApplication()


### PR DESCRIPTION
Inspired by doctrine binary.
This way, openl10n-cli could be included in an existing project by requiring it in a composer.json.
