### PR TITLE
Get the Matcher working on Windows (Directorynames with backslashes)

### DIFF
--- a/src/Openl10n/Cli/File/Matcher.php
+++ b/src/Openl10n/Cli/File/Matcher.php
@@ -65,7 +65,11 @@ class Matcher
         $finder = new Finder();
         $finder->in($inDir)->path($regex);
         foreach ($finder->files() as $file) {
-            if (!preg_match($regex, $file->getRelativePathname(), $matches)) {
+            
+            // Replacing Windows backslashes by linux slashes
+            $relativePathnameSanitized = str_replace("\\", "/", $file->getRelativePathname());
+            
+            if (!preg_match($regex, $relativePathnameSanitized, $matches)) {
                 // Should not happen, but it better to check
                 continue;
             }


### PR DESCRIPTION
Hello Matt,

really great work on all the openl10n-stuff. To get the cli-version working on windows I replaced the win-backslashes by linux backslashes before the matching process.