### PR TITLE
Add behat functional test case for push command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
   - 5.6
   - 5.5
-  - 5.4
 before_script:
   - composer selfupdate
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,9 @@ php:
   - 5.5
   - 5.4
 before_script:
+  - composer selfupdate
   - composer install
+  - export PATH=./bin:$PATH
+
 script: composer test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
 before_script:
   - composer selfupdate
   - composer install
-  - export PATH=./bin:$PATH
 
 script: composer test
 

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,7 @@
+default:
+    suites:
+        cli:
+            paths:
+                - features/cli
+            contexts:
+                - FeatureContext

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "scripts": {
         "test": [
             "phpunit --colors=always",
-            "behat --format=progress --colors"
+            "behat --format=progress --colors --verbose"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "scripts": {
         "test": [
             "phpunit --colors=always",
-            "bin/behat --format=progress"
+            "behat --format=progress"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "project",
     "require": {
         "php": "^5.4",
-        "openl10n/sdk": "dev-master@dev",
+        "openl10n/sdk": "^0.2",
         "symfony/config": "^2.7",
         "symfony/console": "^2.7",
         "symfony/dependency-injection": "^2.7",
@@ -25,7 +25,7 @@
     "scripts": {
         "test": [
             "phpunit --colors=always",
-            "behat --format=progress"
+            "behat --format=progress --colors"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "project",
     "require": {
         "php": "^5.4",
-        "openl10n/sdk": "^0.1",
+        "openl10n/sdk": "dev-master@dev",
         "symfony/config": "^2.7",
         "symfony/console": "^2.7",
         "symfony/dependency-injection": "^2.7",
@@ -14,7 +14,8 @@
         "symfony/yaml": "^2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "behat/behat": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,7 +24,8 @@
     },
     "scripts": {
         "test": [
-            "phpunit --colors=always"
+            "phpunit --colors=always",
+            "bin/behat --format=progress"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "^5.4",
+        "php": "^5.5",
         "openl10n/sdk": "^0.2",
         "symfony/config": "^2.7",
         "symfony/console": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "523458c4da5b0748db25d76d36641436",
+    "hash": "0cd1a6538edacf27d02ecd25fa32f942",
     "content-hash": "4b7769ac1fc0bf33c8d614cb3fc476ca",
     "packages": [
         {
@@ -122,16 +122,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e"
+                "reference": "4d0bdbe1206df7440219ce14c972aa57cc5e4982"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
-                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4d0bdbe1206df7440219ce14c972aa57cc5e4982",
+                "reference": "4d0bdbe1206df7440219ce14c972aa57cc5e4982",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +176,7 @@
                 "stream",
                 "uri"
             ],
-            "time": "2015-08-15 19:32:36"
+            "time": "2015-11-03 01:34:55"
         },
         {
             "name": "openl10n/sdk",
@@ -184,12 +184,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/openl10n/openl10n-sdk.git",
-                "reference": "c268c024ff2e0ea1b41a59cc7427f9a06084c6db"
+                "reference": "2eab19e57f9cc35bc39e39b970c950be09679ff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/c268c024ff2e0ea1b41a59cc7427f9a06084c6db",
-                "reference": "c268c024ff2e0ea1b41a59cc7427f9a06084c6db",
+                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/2eab19e57f9cc35bc39e39b970c950be09679ff5",
+                "reference": "2eab19e57f9cc35bc39e39b970c950be09679ff5",
                 "shasum": ""
             },
             "require": {
@@ -213,7 +213,7 @@
                 }
             ],
             "description": "The API client for openl10n",
-            "time": "2015-10-08 06:47:28"
+            "time": "2015-11-03 12:43:59"
         },
         {
             "name": "psr/http-message",

--- a/composer.lock
+++ b/composer.lock
@@ -4,49 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "513796fb95eb07108318a366959c1e4b",
-    "content-hash": "3f7c0ee1d49eee02267aa45e13e7116e",
+    "hash": "523458c4da5b0748db25d76d36641436",
+    "content-hash": "4b7769ac1fc0bf33c8d614cb3fc476ca",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "4.2.3",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c"
+                "reference": "66fd14b4d0b8f2389eaf37c5458608c7cb793a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/66fd916e9f9130bc22c51450476823391cb2f67c",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/66fd14b4d0b8f2389eaf37c5458608c7cb793a81",
+                "reference": "66fd14b4d0b8f2389eaf37c5458608c7cb793a81",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "guzzlehttp/streams": "~2.1",
-                "php": ">=5.4.0"
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "phpunit/phpunit": "~4.0",
                 "psr/log": "~1.0"
             },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -59,7 +56,7 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -70,24 +67,24 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-10-05 19:29:14"
+            "time": "2015-09-08 17:36:26"
         },
         {
-            "name": "guzzlehttp/streams",
-            "version": "2.1.0",
+            "name": "guzzlehttp/promises",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534"
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "b1e1c0d55f8083c71eda2c28c12a228d708294ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/f91b721d73f0e561410903b3b3c90a5d0e40b534",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/b1e1c0d55f8083c71eda2c28c12a228d708294ea",
+                "reference": "b1e1c0d55f8083c71eda2c28c12a228d708294ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.0"
@@ -95,15 +92,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
+                    "GuzzleHttp\\Promise\\": "src/"
                 },
                 "files": [
-                    "src/functions.php"
+                    "src/functions_include.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -117,35 +114,91 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Provides a simple abstraction over streams of data (Guzzle 4+)",
-            "homepage": "http://guzzlephp.org/",
+            "description": "Guzzle promises library",
             "keywords": [
-                "Guzzle",
-                "stream"
+                "promise"
             ],
-            "time": "2014-08-17 21:15:53"
+            "time": "2015-10-15 22:28:00"
         },
         {
-            "name": "openl10n/sdk",
-            "version": "v0.1",
+            "name": "guzzlehttp/psr7",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/openl10n/openl10n-sdk.git",
-                "reference": "2c6ecb26542e6b502e613555006d61a0a4d3ebea"
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/2c6ecb26542e6b502e613555006d61a0a4d3ebea",
-                "reference": "2c6ecb26542e6b502e613555006d61a0a4d3ebea",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "~4.0"
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-08-15 19:32:36"
+        },
+        {
+            "name": "openl10n/sdk",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openl10n/openl10n-sdk.git",
+                "reference": "c268c024ff2e0ea1b41a59cc7427f9a06084c6db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/c268c024ff2e0ea1b41a59cc7427f9a06084c6db",
+                "reference": "c268c024ff2e0ea1b41a59cc7427f9a06084c6db",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~6.0"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Openl10n\\Sdk": "src"
+                "psr-4": {
+                    "Openl10n\\Sdk\\": "src/Openl10n/Sdk/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -160,7 +213,56 @@
                 }
             ],
             "description": "The API client for openl10n",
-            "time": "2014-09-12 20:28:16"
+            "time": "2015-10-08 06:47:28"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
         },
         {
             "name": "symfony/config",
@@ -521,6 +623,185 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "behat/behat",
+            "version": "v3.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Behat.git",
+                "reference": "b35ae3d45332d80c532af69cc36f780a9397a996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/b35ae3d45332d80c532af69cc36f780a9397a996",
+                "reference": "b35ae3d45332d80c532af69cc36f780a9397a996",
+                "shasum": ""
+            },
+            "require": {
+                "behat/gherkin": "~4.3",
+                "behat/transliterator": "~1.0",
+                "ext-mbstring": "*",
+                "php": ">=5.3.3",
+                "symfony/class-loader": "~2.1",
+                "symfony/config": "~2.3",
+                "symfony/console": "~2.1",
+                "symfony/dependency-injection": "~2.1",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/translation": "~2.3",
+                "symfony/yaml": "~2.1"
+            },
+            "require-dev": {
+                "phpspec/prophecy-phpunit": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "behat/mink-extension": "for integration with Mink testing framework",
+                "behat/symfony2-extension": "for integration with Symfony2 web framework",
+                "behat/yii-extension": "for integration with Yii web framework"
+            },
+            "bin": [
+                "bin/behat"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Behat": "src/",
+                    "Behat\\Testwork": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Scenario-oriented BDD framework for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "Agile",
+                "BDD",
+                "ScenarioBDD",
+                "Scrum",
+                "StoryBDD",
+                "User story",
+                "business",
+                "development",
+                "documentation",
+                "examples",
+                "symfony",
+                "testing"
+            ],
+            "time": "2015-02-22 14:10:33"
+        },
+        {
+            "name": "behat/gherkin",
+            "version": "v4.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Gherkin.git",
+                "reference": "6b3f8cf3560dc4909c4cddd4f1af3e1f6e9d80af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/6b3f8cf3560dc4909c4cddd4f1af3e1f6e9d80af",
+                "reference": "6b3f8cf3560dc4909c4cddd4f1af3e1f6e9d80af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to parse features, represented in YAML files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Gherkin": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Gherkin DSL parser for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Cucumber",
+                "DSL",
+                "gherkin",
+                "parser"
+            ],
+            "time": "2015-09-29 13:41:19"
+        },
+        {
+            "name": "behat/transliterator",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Transliterator.git",
+                "reference": "868e05be3a9f25ba6424c2dd4849567f50715003"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/868e05be3a9f25ba6424c2dd4849567f50715003",
+                "reference": "868e05be3a9f25ba6424c2dd4849567f50715003",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Transliterator": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Artistic-1.0"
+            ],
+            "description": "String transliterator",
+            "keywords": [
+                "i18n",
+                "slug",
+                "transliterator"
+            ],
+            "time": "2015-09-28 16:26:35"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -1422,11 +1703,122 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "symfony/class-loader",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/class-loader.git",
+                "reference": "320f8d2a9cdbcbeb24be602c124aae9d998474a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/320f8d2a9cdbcbeb24be602c124aae9d998474a4",
+                "reference": "320f8d2a9cdbcbeb24be602c124aae9d998474a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/finder": "~2.0,>=2.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ClassLoader\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ClassLoader Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-10-23 14:47:27"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "6ccd9289ec1c71d01a49d83480de3b5293ce30c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/6ccd9289ec1c71d01a49d83480de3b5293ce30c8",
+                "reference": "6ccd9289ec1c71d01a49d83480de3b5293ce30c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/config": "<2.7"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.7",
+                "symfony/intl": "~2.4",
+                "symfony/yaml": "~2.2"
+            },
+            "suggest": {
+                "psr/log": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-10-27 15:38:06"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "openl10n/sdk": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0cd1a6538edacf27d02ecd25fa32f942",
-    "content-hash": "4b7769ac1fc0bf33c8d614cb3fc476ca",
+    "hash": "ca36e5ca885f769fa88ae004c7f63f62",
+    "content-hash": "ec47903e8da5f5de3f0b0c18ead50adf",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -180,16 +180,16 @@
         },
         {
             "name": "openl10n/sdk",
-            "version": "dev-master",
+            "version": "v0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openl10n/openl10n-sdk.git",
-                "reference": "2eab19e57f9cc35bc39e39b970c950be09679ff5"
+                "reference": "1a67c167bf42fefb59d353b1cdcbd9bca1578eef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/2eab19e57f9cc35bc39e39b970c950be09679ff5",
-                "reference": "2eab19e57f9cc35bc39e39b970c950be09679ff5",
+                "url": "https://api.github.com/repos/openl10n/openl10n-sdk/zipball/1a67c167bf42fefb59d353b1cdcbd9bca1578eef",
+                "reference": "1a67c167bf42fefb59d353b1cdcbd9bca1578eef",
                 "shasum": ""
             },
             "require": {
@@ -213,7 +213,7 @@
                 }
             ],
             "description": "The API client for openl10n",
-            "time": "2015-11-03 12:43:59"
+            "time": "2015-11-03 12:39:10"
         },
         {
             "name": "psr/http-message",
@@ -1816,9 +1816,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "openl10n/sdk": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ca36e5ca885f769fa88ae004c7f63f62",
-    "content-hash": "ec47903e8da5f5de3f0b0c18ead50adf",
+    "hash": "a1db0fccc2d4ca946dcb08e750ef7678",
+    "content-hash": "4a40b05a6e73b2df24e327e06a8fb45a",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1820,7 +1820,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.4"
+        "php": "^5.5"
     },
     "platform-dev": []
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,0 +1,391 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+
+class FeatureContext implements Context
+{
+    /**
+     * @var int
+     */
+    private $commandExitCode;
+
+    /**
+     * @var string
+     */
+    private $commandOutput;
+
+    /**
+     * @var \Openl10n\Cli\Application
+     */
+    private $application;
+
+    /**
+     * @var \GuzzleHttp\Handler\MockHandler[]
+     */
+    private $guzzleMockHandlerList;
+
+    /**
+     * @var array
+     */
+    private $guzzleTransactionHistory = array();
+
+    /**
+     * @var string
+     */
+    private $workingDir;
+
+    /**
+     * Cleans test folders in the temporary directory.
+     *
+     * @BeforeSuite
+     * @AfterSuite
+     */
+    public static function cleanTestFolders()
+    {
+        if (is_dir($dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'openl10n')) {
+            self::clearDirectory($dir);
+        }
+    }
+
+    /**
+     * Prepares test folders in the temporary directory.
+     *
+     * @BeforeScenario
+     */
+    public function prepareTestFolders()
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'openl10n' . DIRECTORY_SEPARATOR .
+            md5(microtime() * rand(0, 10000));
+
+        mkdir($dir, 0777, true);
+
+        $this->workingDir = $dir;
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function prepareApplication()
+    {
+        // Move to temporary working dir
+        chdir($this->workingDir);
+
+        $factory = new \Openl10n\Cli\ApplicationFactory();
+        $this->application = $factory->createApplication();
+        $this->application->setAutoExit(false);
+
+    }
+
+    /**
+     * Creates a file with specified name and context in current workdir.
+     *
+     * @Given /^(?:there is )?a file named "([^"]*)" with:$/
+     *
+     * @param string       $filename name of the file (relative path)
+     * @param PyStringNode $content  PyString string instance
+     */
+    public function aFileNamedWith($filename, PyStringNode $content)
+    {
+        $content = strtr((string) $content, array("'''" => '"""'));
+        $this->createFile($this->workingDir . '/' . $filename, $content);
+    }
+
+    /**
+     * Checks whether a file at provided path exists.
+     *
+     * @Given /^file "([^"]*)" should exist$/
+     *
+     * @param   string $path
+     */
+    public function fileShouldExist($path)
+    {
+        PHPUnit_Framework_Assert::assertFileExists($this->workingDir . DIRECTORY_SEPARATOR . $path);
+    }
+
+    /**
+     * Runs openl10n command with provided parameters
+     *
+     * @When /^I run "openl10n(?: ((?:\"|[^"])*))?"$/
+     *
+     * @param string $argumentsString
+     */
+    public function iRunOpenl10n($argumentsString = '')
+    {
+        $argumentsString = strtr($argumentsString, array('\'' => '"'));
+
+        $fh = tmpfile();
+        $input = new \Symfony\Component\Console\Input\StringInput($argumentsString);
+        $output = new \Symfony\Component\Console\Output\StreamOutput($fh);
+
+        $this->commandExitCode = $this->application->run($input, $output);
+
+        fseek($fh, 0);
+        $output = '';
+        while (!feof($fh)) {
+            $output = fread($fh, 4096);
+        }
+        fclose($fh);
+        $this->commandOutput = $output;
+    }
+
+    /**
+     * Checks whether previously ran command passes|fails with provided output.
+     *
+     * @Then /^it should (fail|pass) with:$/
+     *
+     * @param string       $success "fail" or "pass"
+     * @param PyStringNode $text    PyString text instance
+     */
+    public function itShouldPassWith($success, PyStringNode $text)
+    {
+        $this->itShouldFail($success);
+        $this->theOutputShouldContain($text);
+    }
+
+    /**
+     * Checks whether previously runned command passes|failes with no output.
+     *
+     * @Then /^it should (fail|pass) with no output$/
+     *
+     * @param string $success "fail" or "pass"
+     */
+    public function itShouldPassWithNoOutput($success)
+    {
+        $this->itShouldFail($success);
+        PHPUnit_Framework_Assert::assertEmpty($this->getOutput());
+    }
+
+    /**
+     * Checks whether specified file exists and contains specified string.
+     *
+     * @Then /^"([^"]*)" file should contain:$/
+     *
+     * @param string       $path file path
+     * @param PyStringNode $text file content
+     */
+    public function fileShouldContain($path, PyStringNode $text)
+    {
+        $path = $this->workingDir . '/' . $path;
+        PHPUnit_Framework_Assert::assertFileExists($path);
+        $fileContent = trim(file_get_contents($path));
+        // Normalize the line endings in the output
+        if ("\n" !== PHP_EOL) {
+            $fileContent = str_replace(PHP_EOL, "\n", $fileContent);
+        }
+        PHPUnit_Framework_Assert::assertEquals($this->getExpectedOutput($text), $fileContent);
+    }
+    /**
+     * Checks whether specified content and structure of the xml is correct without worrying about layout.
+     *
+     * @Then /^"([^"]*)" file xml should be like:$/
+     *
+     * @param string       $path file path
+     * @param PyStringNode $text file content
+     */
+    public function fileXmlShouldBeLike($path, PyStringNode $text)
+    {
+        $path = $this->workingDir . '/' . $path;
+        PHPUnit_Framework_Assert::assertFileExists($path);
+        $fileContent = trim(file_get_contents($path));
+        $dom = new DOMDocument();
+        $dom->loadXML($text);
+        $dom->formatOutput = true;
+        PHPUnit_Framework_Assert::assertEquals(trim($dom->saveXML(null, LIBXML_NOEMPTYTAG)), $fileContent);
+    }
+
+    /**
+     * Checks whether last command output contains provided string.
+     *
+     * @Then the output should contain:
+     *
+     * @param PyStringNode $text PyString text instance
+     */
+    public function theOutputShouldContain(PyStringNode $text)
+    {
+        PHPUnit_Framework_Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+    }
+
+    private function getExpectedOutput(PyStringNode $expectedText)
+    {
+        $text = strtr($expectedText, array('\'\'\'' => '"""', '%%TMP_DIR%%' => sys_get_temp_dir() . DIRECTORY_SEPARATOR));
+        // windows path fix
+        if ('/' !== DIRECTORY_SEPARATOR) {
+            $text = preg_replace_callback(
+                '/[ "]features\/[^\n "]+/', function ($matches) {
+                return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+            }, $text
+            );
+            $text = preg_replace_callback(
+                '/\<span class\="path"\>features\/[^\<]+/', function ($matches) {
+                return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+            }, $text
+            );
+            $text = preg_replace_callback(
+                '/\+[fd] [^ ]+/', function ($matches) {
+                return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+            }, $text
+            );
+        }
+        return $text;
+    }
+
+    /**
+     * Checks whether previously ran command failed|passed.
+     *
+     * @Then /^it should (fail|pass)$/
+     *
+     * @param string $success "fail" or "pass"
+     */
+    public function itShouldFail($success)
+    {
+        if ('fail' === $success) {
+            if (0 === $this->commandExitCode) {
+                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+            }
+            PHPUnit_Framework_Assert::assertNotEquals(0, $this->commandExitCode);
+        } else {
+            if (0 !== $this->commandExitCode) {
+                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+            }
+            PHPUnit_Framework_Assert::assertEquals(0, $this->commandExitCode);
+        }
+    }
+
+    private function getOutput()
+    {
+        $output = $this->commandOutput;
+        // Normalize the line endings in the output
+        if ("\n" !== PHP_EOL) {
+            $output = str_replace(PHP_EOL, "\n", $output);
+        }
+        // Replace wrong warning message of HHVM
+        $output = str_replace('Notice: Undefined index: ', 'Notice: Undefined offset: ', $output);
+        return trim(preg_replace("/ +$/m", '', $output));
+    }
+
+    private function createFile($filename, $content)
+    {
+        $path = dirname($filename);
+        $this->createDirectory($path);
+        file_put_contents($filename, $content);
+    }
+
+    private function createDirectory($path)
+    {
+        if (!is_dir($path)) {
+            mkdir($path, 0777, true);
+        }
+    }
+
+    private static function clearDirectory($path)
+    {
+        $files = scandir($path);
+        array_shift($files);
+        array_shift($files);
+        foreach ($files as $file) {
+            $file = $path . DIRECTORY_SEPARATOR . $file;
+            if (is_dir($file)) {
+                self::clearDirectory($file);
+            } else {
+                unlink($file);
+            }
+        }
+        rmdir($path);
+    }
+
+    /**
+     * @Given there is a openl10n server serving a :resource resource
+     */
+    public function thereIsAOpenl10nServerAtUri($resource)
+    {
+        $this->guzzleMockHandlerList[$resource] = new \GuzzleHttp\Handler\MockHandler();
+
+        $handler = \GuzzleHttp\HandlerStack::create($this->guzzleMockHandlerList[$resource]);
+
+        $this->guzzleTransactionHistory[$resource] = array();
+        $handler->push(\GuzzleHttp\Middleware::history($this->guzzleTransactionHistory[$resource]));
+
+        $client = new \GuzzleHttp\Client(['handler' => $handler]);
+
+        $this->application
+            ->getContainer()
+            ->get('api')
+            ->getEntryPoint($resource)
+            ->setClient($client);
+    }
+
+    /**
+     * @Given :method call to :resource on :uri will return :statusCode with:
+     */
+    public function httpCallToResourceWillReturnWith($method, $resource, $uri, $statusCode, PyStringNode $stringNode)
+    {
+        $this->guzzleMockHandlerList[$resource]->append(
+            function($request, $options) use ($method, $uri, $statusCode, $stringNode) {
+
+                PHPUnit_Framework_Assert::assertEquals($method, $request->getMethod());
+                PHPUnit_Framework_Assert::assertEquals($uri, $request->getRequestTarget());
+
+                return new \GuzzleHttp\Psr7\Response($statusCode, [], $stringNode->getRaw());
+            }
+        );
+    }
+
+    /**
+     * @Given :method call to :resource on :uri will return :statusCode
+     */
+    public function httpCallToResourceWillReturn($method, $resource, $uri, $statusCode)
+    {
+        $this->guzzleMockHandlerList[$resource]->append(
+            function($request, $options) use ($method, $uri, $statusCode) {
+
+                PHPUnit_Framework_Assert::assertEquals($method, $request->getMethod());
+                PHPUnit_Framework_Assert::assertEquals($uri, $request->getRequestTarget());
+
+                return new \GuzzleHttp\Psr7\Response($statusCode, []);
+            }
+        );
+    }
+
+    /**
+     * @Then I should have :method call to :resource on :uri with:
+     */
+    public function iShouldHaveMethodCallToResourceOnUriWith($method, $resource, $uri, PyStringNode $stringNode)
+    {
+        foreach ($this->guzzleTransactionHistory[$resource] as $key => $transaction) {
+
+            if ($transaction['request']->getMethod() == $method && $transaction['request']->getRequestTarget() == $uri) {
+
+                $reflectionProperty = new \ReflectionProperty($transaction['request'], 'stream');
+                $reflectionProperty->setAccessible(true);
+                $stream = $reflectionProperty->getValue($transaction['request']);
+
+                PHPUnit_Framework_Assert::assertSame(
+                    json_decode($stringNode->getRaw(), true),
+                    json_decode($stream->read($stream->getSize()), true)
+                );
+
+                unset($this->guzzleTransactionHistory[$resource][$key]);
+            }
+        }
+    }
+
+    /**
+     * @Then I should have :method call to :resource on :uri
+     */
+    public function iShouldHaveMethodCallToResourceOnUri($method, $resource, $uri)
+    {
+        $found = false;
+        foreach ($this->guzzleTransactionHistory[$resource] as $key => $transaction) {
+
+            if ($transaction['request']->getMethod() == $method && $transaction['request']->getRequestTarget() == $uri) {
+
+                $found = true;
+
+                unset($this->guzzleTransactionHistory[$resource][$key]);
+            }
+        }
+
+        PHPUnit_Framework_Assert::assertTrue($found);
+    }
+}

--- a/features/cli/push.feature
+++ b/features/cli/push.feature
@@ -1,0 +1,151 @@
+Feature: Provide a push command sending translation to openl10n server
+
+  Background:
+    Given there is a file named ".openl10n.yml" with:
+    """
+    server:
+        hostname: openl10n.server:
+        username: user
+        password : password
+
+    project: my_project
+
+    files:
+        - trans/*.<locale>.yml
+    """
+    And there is a file named "trans/messages.en.yml" with:
+    """
+    foo: bar
+    """
+    And there is a openl10n server serving a "project" resource
+    And there is a openl10n server serving a "resource" resource
+    And "GET" call to "project" on "projects/my_project" will return 200 with:
+    """
+    {
+    "slug": "my_project",
+    "name": "my_project",
+    "default_locale": "en",
+    "description": "Project description"
+    }
+    """
+    And "GET" call to "project" on "projects/my_project/languages" will return 200 with:
+    """
+    [
+    {
+        "locale": "en",
+        "name": "english"
+    },
+    {
+        "locale": "fr",
+        "name": "french"
+    }
+    ]
+    """
+
+  Scenario: Push a new resource to server
+    And "GET" call to "resource" on "resources?project=my_project" will return 200 with:
+    """
+    [
+    ]
+    """
+    And "POST" call to "resource" on "resources" will return 201 with:
+    """
+    {
+        "id": 53,
+        "project": "my_project",
+        "pathname": "trans/messages.en.yml"
+    }
+    """
+    And "POST" call to "resource" on "resources/53/import" will return 204
+    When I run "openl10n push --locale=all"
+    Then it should pass with:
+    """
+    Creating resource trans/messages.en.yml
+    Uploading file trans/messages.en.yml
+    """
+    And I should have "POST" call to "resource" on "resources" with:
+    """
+    {
+    "project": "my_project",
+    "pathname": "trans/messages.en.yml"
+    }
+    """
+    And I should have "POST" call to "resource" on "resources/53/import"
+
+  Scenario: Push an existing resource to server
+    And "GET" call to "resource" on "resources?project=my_project" will return 200 with:
+    """
+    [
+    {
+        "id": 53,
+        "project": "my_project",
+        "pathname": "trans/messages.en.yml"
+    }
+    ]
+    """
+    And "POST" call to "resource" on "resources/53/import" will return 204
+    When I run "openl10n push --locale=all"
+    Then it should pass with:
+    """
+    Uploading file trans/messages.en.yml
+    """
+    And I should have "POST" call to "resource" on "resources/53/import"
+
+  Scenario: Push a specific resource to server
+    And there is a file named "trans/forms.en.yml" with:
+    """
+    foo: bar
+    """
+    And "GET" call to "resource" on "resources?project=my_project" will return 200 with:
+    """
+    [
+    {
+        "id": 53,
+        "project": "my_project",
+        "pathname": "trans/messages.en.yml"
+    },
+    {
+        "id": 57,
+        "project": "my_project",
+        "pathname": "trans/forms.en.yml"
+    }
+    ]
+    """
+    And "POST" call to "resource" on "resources/53/import" will return 204
+    When I run "openl10n push --locale=all trans/messages.en.yml"
+    Then it should pass with:
+    """
+    Uploading file trans/messages.en.yml
+    """
+    And I should have "POST" call to "resource" on "resources/53/import"
+
+  Scenario: Push various resources to server
+    And there is a file named "trans/forms.en.yml" with:
+    """
+    foo: bar
+    """
+    And "GET" call to "resource" on "resources?project=my_project" will return 200 with:
+    """
+    [
+    {
+        "id": 53,
+        "project": "my_project",
+        "pathname": "trans/messages.en.yml"
+    },
+    {
+        "id": 57,
+        "project": "my_project",
+        "pathname": "trans/forms.en.yml"
+    }
+    ]
+    """
+    And "POST" call to "resource" on "resources/57/import" will return 204
+    And "POST" call to "resource" on "resources/53/import" will return 204
+    When I run "openl10n push --locale=all"
+    Then it should pass with:
+    """
+    Uploading file trans/forms.en.yml
+    Uploading file trans/messages.en.yml
+    """
+    And I should have "POST" call to "resource" on "resources/57/import"
+    And I should have "POST" call to "resource" on "resources/53/import"

--- a/src/Openl10n/Cli/Command/InitCommand.php
+++ b/src/Openl10n/Cli/Command/InitCommand.php
@@ -81,7 +81,7 @@ class InitCommand extends AbstractCommand
             $this->configuration['server']['use_ssl'] = 'https' === $scheme;
         }
 
-        if (false === $this->configuration['server']['use_ssl']) {
+        if (isset($this->configuration['server']['use_ssl']) && false === $this->configuration['server']['use_ssl']) {
             unset($this->configuration['server']['use_ssl']);
         }
 


### PR DESCRIPTION
Trying to add some more unit tests, I realized openl10n-cli code isn't that simple and wouldn't be totally trivial to unit test. So I thought that some behat test cases (strongly inspired by the https://github.com/Behat/Behat feature suite herself) could quickly protect the project from regression.

Pending for https://github.com/openl10n/openl10n-sdk/pull/13 to build properly on `php >= 5.5`

Guzzle mocks weren't available on Guzzle 4, so I had to upgrade https://github.com/openl10n/openl10n-sdk on `dev-master`, may could you release a new version of https://github.com/openl10n/openl10n-sdk ?

Of course if adding functionnal tests wasn't in your plans feel free to close this pull request.